### PR TITLE
Load available timezones in route to avoid promise headaches

### DIFF
--- a/core/client/app/controllers/settings/general.js
+++ b/core/client/app/controllers/settings/general.js
@@ -15,6 +15,8 @@ export default Controller.extend(SettingsSaveMixin, {
     showUploadLogoModal: false,
     showUploadCoverModal: false,
 
+    availableTimezones: null,
+
     notifications: service(),
     config: service(),
     timeZone: service(),
@@ -33,13 +35,13 @@ export default Controller.extend(SettingsSaveMixin, {
         return selectedTheme;
     }),
 
-    selectedTimezone: computed('model.activeTimezone', 'config.availableTimezones', function () {
+    selectedTimezone: computed('model.activeTimezone', 'availableTimezones', function () {
         let [ activeTimezone ] = this.get('model.activeTimezone');
-        let availableTimezones = this.get('config.availableTimezones');
+        let availableTimezones = this.get('availableTimezones');
 
-        return availableTimezones.then((timezones) => {
-            return timezones.filterBy('name', activeTimezone).get('firstObject');
-        });
+        return availableTimezones
+            .filterBy('name', activeTimezone)
+            .get('firstObject.name');
     }),
 
     logoImageSource: computed('model.logo', function () {

--- a/core/client/app/routes/settings/general.js
+++ b/core/client/app/routes/settings/general.js
@@ -1,11 +1,19 @@
+import Ember from 'ember';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
+
+const {
+    RSVP,
+    inject: {service}
+} = Ember;
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - General',
 
     classNames: ['settings-view-general'],
+
+    config: service(),
 
     beforeModel() {
         this._super(...arguments);
@@ -15,9 +23,15 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     },
 
     model() {
-        return this.store.query('setting', {type: 'blog,theme,private'}).then((records) => {
-            return records.get('firstObject');
+        return RSVP.hash({
+            settings: this.store.queryRecord('setting', {type: 'blog,theme,private'}),
+            availableTimezones: this.get('config.availableTimezones')
         });
+    },
+
+    setupController(controller, models) {
+        controller.set('model', models.settings);
+        controller.set('availableTimezones', models.availableTimezones);
     },
 
     actions: {

--- a/core/client/app/templates/settings/general.hbs
+++ b/core/client/app/templates/settings/general.hbs
@@ -112,7 +112,7 @@
                         {{gh-select-native
                             id="activeTimezone"
                             name="general[activeTimezone]"
-                            content=config.availableTimezones
+                            content=availableTimezones
                             optionValuePath="name"
                             optionLabelPath="label"
                             selection=selectedTimezone


### PR DESCRIPTION
no issue
- `gh-select-native` doesn't handle promises at all 😖. To work around it, this PR uses the settings/general route's `model()` and `setupController()` hooks to perform it's async operations before the screen is displayed

For more info, this is a good resource about loading multiple models in the route hooks: http://emberigniter.com/load-multiple-models-single-route/

An alternative to this PR (and the better approach if we need to re-use it) would be to create a `gh-timezone-select` component that properly handles the `config.availableTimezones` promise. If going that route, rather than making further use of the `gh-select-native` component I would suggest using the `one-way-select` component from [ember-one-way-controls](https://github.com/DockYard/ember-one-way-controls)
