### PR TITLE
Fix timezone select

### DIFF
--- a/core/client/app/controllers/settings/general.js
+++ b/core/client/app/controllers/settings/general.js
@@ -39,7 +39,7 @@ export default Controller.extend(SettingsSaveMixin, {
         let availableTimezones = this.get('availableTimezones');
         return availableTimezones
             .filterBy('name', activeTimezone)
-            .get('firstObject.name');
+            .get('firstObject');
     }),
 
     logoImageSource: computed('model.logo', function () {
@@ -51,7 +51,7 @@ export default Controller.extend(SettingsSaveMixin, {
     }),
 
     localTime: computed('selectedTimezone', function () {
-        let offset = this.get('selectedTimezone');
+        let offset = this.get('selectedTimezone.name');
         // if selectedTimezone is not set, take UTC time as default
         // because our default Timezone is UTC as well
         return offset ? moment.tz(offset).format('HH:mm') : moment.utc().format('HH:mm');

--- a/core/client/app/templates/settings/general.hbs
+++ b/core/client/app/templates/settings/general.hbs
@@ -108,7 +108,7 @@
 
                 <div class="form-group for-select">
                     <label for="activeTimezone">Timezone</label>
-                    <span class="gh-select" data-select-text="{{selectedTimezone}}" tabindex="0">
+                    <span class="gh-select" data-select-text="{{selectedTimezone.label}}" tabindex="0">
                         {{gh-select-native
                             id="activeTimezone"
                             name="general[activeTimezone]"


### PR DESCRIPTION
no issue
- updates `selectedTimezone` to return the matching object from `availableTimezones`

The select box wasn't selecting the correct option because the `selection` property passed to `gh-select-native` must match an _object_ in it's `content` property, not just a name.
