### PR TITLE
Added `verificationFlow`-gated verification test coverage

### DIFF
--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -24,6 +24,7 @@ const DomainEvents = require('@tryghost/domain-events');
 const logging = require('@tryghost/logging');
 const {stripeMocker} = require('../../utils/e2e-framework-mock-manager');
 const settingsHelpers = require('../../../core/server/services/settings-helpers');
+const {setupMockVerificationWebhook} = require('../../utils/verification-webhook-test-utils.ts');
 
 async function assertMemberEvents({eventType, memberId, asserts}) {
     const events = await models[eventType].where('member_id', memberId).fetchAll();
@@ -62,6 +63,42 @@ async function createMember(data) {
     });
 
     return member;
+}
+
+function mockAdminVerificationSignupEvents({memberTotal = 0} = {}) {
+    let adminTotal = 0;
+
+    return sinon.stub(membersService.api.events, 'getSignupEvents').callsFake(async (_options, filter) => {
+        if (filter?.source === 'admin') {
+            adminTotal += 1;
+
+            return {
+                meta: {
+                    pagination: {
+                        total: adminTotal
+                    }
+                }
+            };
+        }
+
+        if (filter?.source === 'member') {
+            return {
+                meta: {
+                    pagination: {
+                        total: memberTotal
+                    }
+                }
+            };
+        }
+
+        return {
+            meta: {
+                pagination: {
+                    total: 0
+                }
+            }
+        };
+    });
 }
 
 const newsletterSnapshot = {
@@ -960,118 +997,94 @@ describe('Members API', function () {
 
     it('Can add a member and trigger host webhook verification limits', async function () {
         mockManager.mockLabsEnabled('verificationFlow');
-        const webhookUrl = 'https://test-webhook-receiver.com/mock-verification-event-endpoint/';
-        const webhookSecret = 'not-a-live-secret';
-        const receivedWebhookRequests = [];
-        const webhookEndpoint = new URL(webhookUrl);
+        const {webhookSecret, receivedWebhookRequests} = setupMockVerificationWebhook({persist: true});
+        const signupEventsStub = mockAdminVerificationSignupEvents();
+        let memberPassVerification;
+        let memberFailVerification;
 
-        configUtils.set('hostSettings:siteId', '1');
-        configUtils.set('hostSettings:emailVerification', {
-            apiThreshold: 0,
-            adminThreshold: 1,
-            importThreshold: 0,
-            verified: false,
-            escalationAddress: 'test@example.com',
-            webhookType: 'mock_verification_event',
-            webhookUrl,
-            webhookSecret
-        });
+        try {
+            assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
 
-        nock(webhookEndpoint.origin)
-            .persist()
-            .post(webhookEndpoint.pathname)
-            .reply(function (_uri, requestBody) {
-                const rawBody = Buffer.isBuffer(requestBody) ?
-                    requestBody.toString('utf8') :
-                    typeof requestBody === 'string' ?
-                        requestBody :
-                        JSON.stringify(requestBody);
-                const parsedBody = typeof requestBody === 'object' && !Buffer.isBuffer(requestBody) ?
-                    requestBody :
-                    JSON.parse(rawBody);
+            const member = {
+                name: 'pass webhook verification',
+                email: 'memberPassWebhookVerification@test.com'
+            };
 
-                receivedWebhookRequests.push({
-                    body: parsedBody,
-                    headers: this.req.headers,
-                    rawBody
+            const {body: passBody} = await agent
+                .post(`/members/`)
+                .body({members: [member]})
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag,
+                    location: anyLocationFor('members')
                 });
+            memberPassVerification = passBody.members[0];
 
-                return [200, {status: 'OK'}];
+            await DomainEvents.allSettled();
+            assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+
+            const memberFailLimit = {
+                name: 'fail webhook verification',
+                email: 'memberFailWebhookVerification@test.com'
+            };
+
+            const {body: failBody} = await agent
+                .post(`/members/`)
+                .body({members: [memberFailLimit]})
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag,
+                    location: anyLocationFor('members')
+                });
+            memberFailVerification = failBody.members[0];
+
+            await DomainEvents.allSettled();
+            assert.ok(settingsCache.get('email_verification_required'), 'Email verification should be required');
+            emailMockReceiver.assertSentEmailCount(0);
+
+            const matchingRequest = receivedWebhookRequests.find((request) => {
+                return request.body.type === 'mock_verification_event' &&
+                    request.body.siteId === '1' &&
+                    request.body.amountTriggered === 2 &&
+                    request.body.threshold === 1 &&
+                    request.body.method === 'admin';
             });
 
-        assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+            assert.ok(matchingRequest, 'Expected the verification webhook request to be sent with the configured payload');
 
-        const member = {
-            name: 'pass webhook verification',
-            email: 'memberPassWebhookVerification@test.com'
-        };
+            const requestTimestamp = Array.isArray(matchingRequest.headers['x-ghost-request-timestamp']) ?
+                matchingRequest.headers['x-ghost-request-timestamp'][0] :
+                matchingRequest.headers['x-ghost-request-timestamp'];
+            const requestSignature = Array.isArray(matchingRequest.headers['x-ghost-signature']) ?
+                matchingRequest.headers['x-ghost-signature'][0] :
+                matchingRequest.headers['x-ghost-signature'];
+            const expectedSignature = crypto.createHmac('sha256', webhookSecret)
+                .update(`${requestTimestamp}:${matchingRequest.rawBody}`)
+                .digest('base64');
 
-        const {body: passBody} = await agent
-            .post(`/members/`)
-            .body({members: [member]})
-            .expectStatus(201)
-            .matchBodySnapshot({
-                members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
-            })
-            .matchHeaderSnapshot({
-                'content-version': anyContentVersion,
-                etag: anyEtag,
-                location: anyLocationFor('members')
-            });
-        const memberPassVerification = passBody.members[0];
+            assert.ok(requestTimestamp, 'Expected the verification webhook request to include a timestamp header');
+            assert.equal(requestSignature, expectedSignature, 'Expected the verification webhook request to be signed');
+        } finally {
+            signupEventsStub.restore();
+            await configUtils.restore();
+            nock.cleanAll();
 
-        await DomainEvents.allSettled();
-        assert.ok(!settingsCache.get('email_verification_required'), 'Email verification should NOT be required');
+            if (memberPassVerification?.id) {
+                await agent.delete(`/members/${memberPassVerification.id}`);
+            }
 
-        const memberFailLimit = {
-            name: 'fail webhook verification',
-            email: 'memberFailWebhookVerification@test.com'
-        };
-
-        const {body: failBody} = await agent
-            .post(`/members/`)
-            .body({members: [memberFailLimit]})
-            .expectStatus(201)
-            .matchBodySnapshot({
-                members: new Array(1).fill(buildMemberMatcherShallowIncludesWithTiers(0, 2))
-            })
-            .matchHeaderSnapshot({
-                'content-version': anyContentVersion,
-                etag: anyEtag,
-                location: anyLocationFor('members')
-            });
-        const memberFailVerification = failBody.members[0];
-
-        await DomainEvents.allSettled();
-        assert.ok(settingsCache.get('email_verification_required'), 'Email verification should be required');
-        emailMockReceiver.assertSentEmailCount(0);
-
-        const matchingRequest = receivedWebhookRequests.find((request) => {
-            return request.body.type === 'mock_verification_event' &&
-                request.body.siteId === '1' &&
-                request.body.amountTriggered === 2 &&
-                request.body.threshold === 1 &&
-                request.body.method === 'admin';
-        });
-
-        assert.ok(matchingRequest, 'Expected the verification webhook request to be sent with the configured payload');
-
-        const requestTimestamp = Array.isArray(matchingRequest.headers['x-ghost-request-timestamp']) ?
-            matchingRequest.headers['x-ghost-request-timestamp'][0] :
-            matchingRequest.headers['x-ghost-request-timestamp'];
-        const requestSignature = Array.isArray(matchingRequest.headers['x-ghost-signature']) ?
-            matchingRequest.headers['x-ghost-signature'][0] :
-            matchingRequest.headers['x-ghost-signature'];
-        const expectedSignature = crypto.createHmac('sha256', webhookSecret)
-            .update(`${requestTimestamp}:${matchingRequest.rawBody}`)
-            .digest('base64');
-
-        assert.ok(requestTimestamp, 'Expected the verification webhook request to include a timestamp header');
-        assert.equal(requestSignature, expectedSignature, 'Expected the verification webhook request to be signed');
-
-        // state cleanup
-        await agent.delete(`/members/${memberPassVerification.id}`);
-        await agent.delete(`/members/${memberFailVerification.id}`);
+            if (memberFailVerification?.id) {
+                await agent.delete(`/members/${memberFailVerification.id}`);
+            }
+        }
     });
 
     it('Can add and send a signup confirmation email', async function () {

--- a/ghost/core/test/integration/services/email-service/batch-sending.test.js
+++ b/ghost/core/test/integration/services/email-service/batch-sending.test.js
@@ -1,6 +1,7 @@
 const {agentProvider, fixtureManager, mockManager} = require('../../../utils/e2e-framework');
 const moment = require('moment');
 const models = require('../../../../core/server/models');
+const nock = require('nock');
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const jobManager = require('../../../../core/server/services/jobs/job-service');
@@ -11,6 +12,7 @@ const DomainEvents = require('@tryghost/domain-events');
 const emailService = require('../../../../core/server/services/email-service');
 const {mockSetting, stripeMocker} = require('../../../utils/e2e-framework-mock-manager');
 const {sendEmail, sendFailedEmail, matchEmailSnapshot, getDefaultNewsletter, retryEmail} = require('../../../utils/batch-email-utils');
+const {setupMockVerificationWebhook} = require('../../../utils/verification-webhook-test-utils.ts');
 
 const mobileDocExample = '{"version":"0.3.1","atoms":[],"cards":[],"markups":[],"sections":[[1,"p",[[0,[],0,"Hello world"]]]],"ghostVersion":"4.0"}';
 const mobileDocWithPaywall = '{"version":"0.3.1","markups":[],"atoms":[],"cards":[["paywall",{}]],"sections":[[1,"p",[[0,[],0,"Free content"]]],[10,0],[1,"p",[[0,[],0,"Members content"]]]]}';
@@ -23,6 +25,61 @@ const mobileDocWithReplacements = '{"version":"0.3.1","atoms":[],"cards":[["emai
 let agent;
 let stubbedSend;
 let frontendAgent;
+
+async function assertVerificationRequiredBlocksEmailSend(requestAgent) {
+    const {scope: webhookScope} = setupMockVerificationWebhook({
+        apiThreshold: 100,
+        adminThreshold: 100,
+        importThreshold: 100
+    });
+
+    const members = require('../../../../core/server/services/members');
+    const events = members.api.events;
+    const getSignupEvents = sinon.stub(events, 'getSignupEvents').resolves({
+        meta: {
+            pagination: {
+                total: 100000
+            }
+        }
+    });
+
+    try {
+        assert.equal(settingsCache.get('email_verification_required'), false, 'This test requires email verification to be disabled initially');
+
+        const post = {
+            title: 'A random test post',
+            status: 'draft',
+            feature_image_alt: 'Testing sending',
+            feature_image_caption: 'Testing <b>feature image caption</b>',
+            created_at: moment().subtract(2, 'days').toISOString(),
+            updated_at: moment().subtract(2, 'days').toISOString()
+        };
+
+        const res = await requestAgent.post('posts/')
+            .body({posts: [post]})
+            .expectStatus(201);
+
+        const id = res.body.posts[0].id;
+
+        const updatedPost = {
+            status: 'published',
+            updated_at: res.body.posts[0].updated_at
+        };
+
+        const newsletterSlug = fixtureManager.get('newsletters', 0).slug;
+        await requestAgent.put(`posts/${id}/?newsletter=${newsletterSlug}`)
+            .body({posts: [updatedPost]})
+            .expectStatus(403);
+
+        sinon.assert.calledTwice(getSignupEvents);
+        assert.equal(settingsCache.get('email_verification_required'), true);
+        assert.equal(webhookScope.isDone(), true);
+    } finally {
+        getSignupEvents.restore();
+        await configUtils.restore();
+        nock.cleanAll();
+    }
+}
 
 function sortBatches(a, b) {
     const aId = a.get('provider_id');
@@ -83,6 +140,50 @@ async function testEmailBatches(settings, email_recipient_filter, expectedBatche
     const memberIds = emailRecipients.map(recipient => recipient.get('member_id'));
     assert.equal(memberIds.length, _.uniq(memberIds).length);
 }
+
+describe('Email verification checks', function () {
+    let verificationAgent;
+    let verificationGhostServer;
+
+    before(async function () {
+        const agents = await agentProvider.getAgentsWithFrontend();
+        verificationAgent = agents.adminAgent;
+        verificationGhostServer = agents.ghostServer;
+
+        await fixtureManager.init('newsletters', 'members:newsletters');
+        await verificationAgent.loginAsOwner();
+    });
+
+    beforeEach(function () {
+        mockManager.mockLabsEnabled('verificationFlow');
+        stubbedSend = sinon.fake.resolves({
+            id: 'stubbed-email-id'
+        });
+        mockManager.mockMail();
+        mockManager.mockMailgun(function () {
+            return stubbedSend.call(this, ...arguments);
+        });
+        mockManager.mockStripe();
+    });
+
+    afterEach(async function () {
+        settingsCache.set('email_verification_required', {value: false});
+        mockManager.restore();
+        await jobManager.allSettled();
+        nock.cleanAll();
+    });
+
+    after(async function () {
+        mockManager.restore();
+        if (verificationGhostServer) {
+            await verificationGhostServer.stop();
+        }
+    });
+
+    it('Blocks email sending when verificationFlow is enabled', async function () {
+        await assertVerificationRequiredBlocksEmailSend(verificationAgent);
+    });
+});
 
 // The batch sending tests have some sort of ordering issue that causes them to fail intermittently
 // We need to decide if they are worth keeping, or if we should rewrite them to be more reliable

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -5,7 +5,6 @@ const localUtils = require('./utils');
 const config = require('../../../../core/shared/config');
 const configUtils = require('../../../utils/config-utils');
 const settingsCache = require('../../../../core/shared/settings-cache');
-const models = require('../../../../core/server/models');
 const jobManager = require('../../../../core/server/services/jobs/job-service');
 
 const {mockManager} = require('../../../utils/e2e-framework');
@@ -306,10 +305,7 @@ describe('Members Importer API', function () {
     });
 
     it('Can import members with host emailVerification limits for large imports', async function () {
-        await models.Settings.edit([{
-            key: 'email_verification_required',
-            value: false
-        }], {context: {internal: true}});
+        settingsCache.set('email_verification_required', {value: false});
 
         assert(!settingsCache.get('email_verification_required'), 'Email verification should not be required');
 

--- a/ghost/core/test/utils/verification-webhook-test-utils.ts
+++ b/ghost/core/test/utils/verification-webhook-test-utils.ts
@@ -1,0 +1,79 @@
+import nock from 'nock';
+
+const configUtils = require('./config-utils');
+
+type VerificationWebhookRequestRecord = {
+    body: Record<string, unknown>;
+    headers: Record<string, string | string[] | undefined>;
+    rawBody: string;
+};
+
+type SetupVerificationWebhookOptions = {
+    apiThreshold?: number;
+    adminThreshold?: number;
+    importThreshold?: number;
+    persist?: boolean;
+    siteId?: string;
+};
+
+const DEFAULT_WEBHOOK_URL = 'https://test-webhook-receiver.com/mock-verification-event-endpoint/';
+const DEFAULT_WEBHOOK_SECRET = 'not-a-live-secret';
+const DEFAULT_WEBHOOK_TYPE = 'mock_verification_event';
+
+export function setupMockVerificationWebhook({
+    apiThreshold = 0,
+    adminThreshold = 1,
+    importThreshold = 0,
+    persist = false,
+    siteId = '1'
+}: SetupVerificationWebhookOptions = {}) {
+    const receivedWebhookRequests: VerificationWebhookRequestRecord[] = [];
+    const webhookUrl = DEFAULT_WEBHOOK_URL;
+    const webhookSecret = DEFAULT_WEBHOOK_SECRET;
+    const webhookEndpoint = new URL(webhookUrl);
+
+    configUtils.set('hostSettings:siteId', siteId);
+    configUtils.set('hostSettings:emailVerification', {
+        apiThreshold,
+        adminThreshold,
+        importThreshold,
+        verified: false,
+        escalationAddress: 'test@example.com',
+        webhookType: DEFAULT_WEBHOOK_TYPE,
+        webhookUrl,
+        webhookSecret
+    });
+
+    const scope = nock(webhookEndpoint.origin);
+
+    if (persist) {
+        scope.persist();
+    }
+
+    scope.post(webhookEndpoint.pathname)
+        .reply(function (_uri: string, requestBody: Buffer | string | Record<string, unknown>) {
+            const rawBody = Buffer.isBuffer(requestBody) ?
+                requestBody.toString('utf8') :
+                typeof requestBody === 'string' ?
+                    requestBody :
+                    JSON.stringify(requestBody);
+            const parsedBody = typeof requestBody === 'object' && !Buffer.isBuffer(requestBody) ?
+                requestBody :
+                JSON.parse(rawBody);
+
+            receivedWebhookRequests.push({
+                body: parsedBody as Record<string, unknown>,
+                headers: this.req.headers,
+                rawBody
+            });
+
+            return [200, {status: 'OK'}];
+        });
+
+    return {
+        webhookSecret,
+        webhookUrl,
+        receivedWebhookRequests,
+        scope
+    };
+}


### PR DESCRIPTION
ref [GVA-732](https://linear.app/ghost/issue/GVA-732/roll-out-to-ga-and-remove-old-logic-in-ghost)

This prep PR isolates the flag-aware verification test updates so the GA rollout PR can focus on removing the labs and legacy runtime paths. It adds a shared webhook test helper, makes the admin members webhook e2e test deterministic while keeping it gated behind `verificationFlow`, adds isolated batch-sending coverage for the flag-enabled path, and switches the importer test reset to `settingsCache`.